### PR TITLE
Bugfix/HLD-17 - Goal's page tab is called "strategy". Change it to Objetivos

### DIFF
--- a/src/components/StrategyComponent/StrategyComponent.tsx
+++ b/src/components/StrategyComponent/StrategyComponent.tsx
@@ -34,8 +34,6 @@ export default function StrategyComponent({
         defaultTab={{ title: 'Ações', name: 'stocks' }}
       >
         {(activeTab: any) => {
-          console.log('activeTab: ', activeTab)
-
           return (
             <StrategyTabContent tab={activeTab} onDeleteItem={onDeleteItem} />
           )

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -10,8 +10,6 @@ interface TabsProps {
 }
 
 const Tabs: React.FC<TabsProps> = ({ assetTypes, activeTab, setActiveTab }) => {
-  console.log('assetTypes: ', assetTypes)
-
   return (
     <S.TabsHeader>
       {assetTypes.map((assetType: IAssetTypesList, index: number) => (

--- a/src/pages/definitions.tsx
+++ b/src/pages/definitions.tsx
@@ -32,7 +32,7 @@ const DefinitionsComponent = () => {
 
   return (
     <>
-      <Template tabTitle={'indicators'}>
+      <Template tabTitle="definições">
         <section>
           <SearchBar
             setSearchText={handleSearch}

--- a/src/pages/goals.tsx
+++ b/src/pages/goals.tsx
@@ -21,7 +21,7 @@ export default function Goals({
   overviewSectors
 }: IGoals) {
   return (
-    <Template tabTitle="strategy">
+    <Template tabTitle="objetivos">
       <InvestmentPercentages
         {...{
           stockSectors,

--- a/src/pages/how-to-start.tsx
+++ b/src/pages/how-to-start.tsx
@@ -12,7 +12,7 @@ const HowToStart = () => {
 
   return (
     <>
-      <Template tabTitle="strategy">
+      <Template tabTitle="Como começar">
         <TextLayout>
           <StepsProvider>
             <Steps steps={steps}></Steps>

--- a/src/pages/strategy.tsx
+++ b/src/pages/strategy.tsx
@@ -4,7 +4,7 @@ import StrategyForm from '@features/strategy/StrategyForm/StrategyForm'
 
 const Strategy = () => {
   return (
-    <Template tabTitle="strategy">
+    <Template tabTitle="estratégia">
       <StrategyForm></StrategyForm>
     </Template>
   )


### PR DESCRIPTION
Fixed a few tab names and removed console.logs

📝 (StrategyComponent.tsx): Remove console.log statement for activeTab variable
📝 (Tabs.tsx): Remove console.log statement for assetTypes variable
📝 (definitions.tsx): Change tabTitle value from 'indicators' to 'definições'
📝 (goals.tsx): Change tabTitle value from 'strategy' to 'objetivos'
📝 (how-to-start.tsx): Change tabTitle value from 'strategy' to 'Como começar'
📝 (strategy.tsx): Change tabTitle value from 'strategy' to 'estratégia'